### PR TITLE
Fix for issue #14

### DIFF
--- a/cpp/main/Seb.C
+++ b/cpp/main/Seb.C
@@ -222,7 +222,17 @@ namespace SEB_NAMESPACE {
       Float scale = find_stop_fraction(stopper);
       SEB_LOG ("debug","  stop fraction = " << scale << std::endl);
       
-      if (stopper >= 0) {
+      // Note: In theory, the following if-statement should simply read
+      //
+      //  if (stopper >= 0) {
+      //    // ...
+      //
+      // However, due to rounding errors, it may happen in practice that
+      // stopper is nonnegative and the support is already full (see #14);
+      // in this casev we cannot add yet another point to the support.
+      //
+      // Therefore, the condition reads:
+      if (stopper >= 0 && support->size() <= dim) {
         // stopping point exists
         
         // walk as far as we can


### PR DESCRIPTION
Fixes a problem when, due to numerical errors, the algorithm tries to add a point to the support set when the latter is already full (i.e., contains _d+1_ points). This PR modifies the test to decide when to add a point to the support in such a way that points are only added when the support is not yet full.
