### PR TITLE
Fix filenames: do not use .C for (essentially) templated header files

### DIFF
--- a/cpp/main/Seb-inl.h
+++ b/cpp/main/Seb-inl.h
@@ -3,11 +3,11 @@
 // Authors: Martin Kutz <kutz@math.fu-berlin.de>,
 //          Kaspar Fischer <kf@iaeth.ch>
 
-#ifndef SEB_SEB_C
-#define SEB_SEB_C
+#ifndef SEB_SEB_INL_H
+#define SEB_SEB_INL_H
 
-#include <numeric>
 #include <algorithm>
+#include <numeric>
 
 #include "Seb.h" // Note: header included for better syntax highlighting in some IDEs.
 
@@ -443,4 +443,4 @@ namespace SEB_NAMESPACE {
   
 } // namespace SEB_NAMESPACE
 
-#endif // SEB_SEB_C
+#endif // SEB_SEB_INL_H

--- a/cpp/main/Seb.h
+++ b/cpp/main/Seb.h
@@ -175,6 +175,6 @@ namespace SEB_NAMESPACE {
   
 } // namespace SEB_NAMESPACE
 
-#include "Seb.C"
+#include "Seb-inl.h"
 
 #endif // SEB_SEB_H

--- a/cpp/main/Seb_configure.h
+++ b/cpp/main/Seb_configure.h
@@ -7,8 +7,8 @@
 #define SEB_CONFIGURE_H
 
 #include <cassert>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 
 #define SEB_NAMESPACE Seb              // namespace of the library
 // #define SEB_ASSERTION_MODE          // enables (cheap) assertions

--- a/cpp/main/Seb_debug.C
+++ b/cpp/main/Seb_debug.C
@@ -4,8 +4,8 @@
 //          Kaspar Fischer <kf@iaeth.ch>
 
 #include <cmath>
-#include <sys/time.h>
 #include <sys/resource.h>
+#include <sys/time.h>
 
 #include "Seb_configure.h"
 
@@ -120,4 +120,4 @@ namespace SEB_NAMESPACE {
     return now.ru_utime.tv_sec + now.ru_utime.tv_usec * 1e-6;
   }
   
-  } // namespace SEB_NAMESPACE
+} // namespace SEB_NAMESPACE

--- a/cpp/main/Seb_debug.h
+++ b/cpp/main/Seb_debug.h
@@ -6,11 +6,11 @@
 #ifndef SEB_DEBUG_H
 #define SEB_DEBUG_H
 
+#include <fstream>
 #include <map>
 #include <string>
-#include <fstream>
-#include <sys/time.h>
 #include <sys/resource.h>
+#include <sys/time.h>
 
 namespace SEB_NAMESPACE {
   

--- a/cpp/main/Subspan-inl.h
+++ b/cpp/main/Subspan-inl.h
@@ -3,13 +3,15 @@
 // Authors: Martin Kutz <kutz@math.fu-berlin.de>,
 //          Kaspar Fischer <kf@iaeth.ch>
 
-#ifndef SEB_SUBSPAN_C
-#define SEB_SUBSPAN_C
+#ifndef SEB_SUBSPAN_INL_H
+#define SEB_SUBSPAN_INL_H
 
-#include <numeric>
 #include <cmath>
+#include <numeric>
+#include <ostream>
+#include "Seb_configure.h"
 
-#include "Subspan.h" // Note: header included for better syntax highlighting in some IDEs.
+#include "Subspan.h"  // Note: header included for better syntax highlighting in some IDEs.
 
 // The point members[r] is called the origin; we use the following macro
 // to increase the readibilty of the code:
@@ -369,4 +371,4 @@ namespace SEB_NAMESPACE {
   
 } // namespace SEB_NAMESPACE
 
-#endif // SEB_SUBSPAN_C
+#endif // SEB_SUBSPAN_INL_H

--- a/cpp/main/Subspan.h
+++ b/cpp/main/Subspan.h
@@ -6,6 +6,9 @@
 #ifndef SEB_SUBSPAN_H
 #define SEB_SUBSPAN_H
 
+#include <vector>
+#include "Seb_configure.h"
+
 namespace SEB_NAMESPACE {
   
   template<typename Float>
@@ -159,7 +162,7 @@ namespace SEB_NAMESPACE {
     // in M.  The point members[r] is called the "origin."
     std::vector<unsigned int> members;
     
-  private: // member fields for maintainin the QR-decomposition:
+  private: // member fields for maintaining the QR-decomposition:
     Float **Q, **R;                    // (dim x dim)-matrices Q
     // (orthogonal) and R (upper
     // triangular); notice that
@@ -171,6 +174,6 @@ namespace SEB_NAMESPACE {
   
 } // namespace SEB_NAMESPACE
 
-#include "Subspan.C"
+#include "Subspan-inl.h"
 
 #endif // SEB_SUBSPAN_H

--- a/cpp/test/example.C
+++ b/cpp/test/example.C
@@ -7,7 +7,7 @@
 #include <cstdio>
 
 #include "Seb.h"
-#include "Seb_debug.C" // ... only needed because we use Seb::Timer below
+#include "Seb_debug.h" // ... only needed because we use Seb::Timer below
 
 int main(int argn,char **argv) {
   typedef double FT;


### PR DESCRIPTION
When compiling using Eclipse CDT, *.C files are treated as standard C++ source files. However, since two of them contain template code and are actually meant to be included (!) by other C++ files, Eclipse would fail compilation. To fight this, the offending files have been renamed from *.C to *-inl.h (loosely based on the Google Style Guidelines). Additionally, the provided example.C file no longer includes the (now renamed) file Seb_debug.C, but Seb_debug.h instead (which includes Seb_debug-inl.h).

I believe this way standard C++ practice is followed more closely: header files (including template code) goes into .h (or .hpp), source files go into .C (or .cpp, etc.).

This patch therefore contains the following proposed changes:
- Rename templated .C files to -inl.h (to prevent confusion);
- Complement (add missing) and reorder (alphabetize) includes;
