### PR TITLE
Add array support (in addition to std::vector)

### DIFF
--- a/cpp/main/Subspan.h
+++ b/cpp/main/Subspan.h
@@ -17,7 +17,7 @@ namespace SEB_NAMESPACE {
     return x * x;
   }
   
-  template<typename Float, class Pt, class PointAccessor>
+  template<typename Float, class Pt>
   class Subspan
   // An instance of this class represents the affine hull of a
   // non-empty set M of affinely independent points.  The set M is not
@@ -33,7 +33,7 @@ namespace SEB_NAMESPACE {
   //   between 0 and dim+1.
   //   Complexity: O(1).
   //
-  // - bool is_member(int global_index) returns true iff S[global_index]
+  // - bool is_member(int global_index) returns true iff points[global_index]
   //   is a member of M.
   //   Complexity: O(1)
   //
@@ -76,11 +76,11 @@ namespace SEB_NAMESPACE {
   {
   public: // construction and deletion:
     
-    Subspan(unsigned int dim, const PointAccessor& S, int i);
+    Subspan(unsigned int dim, const Pt* points, const size_t num_points, int i);
     // Constructs an instance representing the affine hull aff(M) of M={p},
-    // where p is the point S[i] from S.
+    // where p is the point with index i from the set.
     //
-    // Notice that S must not changed as long as this instance of
+    // Notice that point set must not change as long as this instance of
     // Subspan<Float> is in use.
     
     ~Subspan();
@@ -99,7 +99,7 @@ namespace SEB_NAMESPACE {
     
     bool is_member(unsigned int i) const
     {
-      SEB_ASSERT(i < S.size());
+      SEB_ASSERT(i < num_points);
       return membership[i];
     }
     
@@ -152,8 +152,9 @@ namespace SEB_NAMESPACE {
     // A + u [1,...,1] = Q' R'.
     
   private: // member fields:
-    const PointAccessor &S;            // a const-reference to the set S
-    std::vector<bool> membership;      // S[i] in M iff membership[i]
+    const Pt* points;                  // points and num_points are the set of inserted
+    const size_t num_points;           // points, formally referred to as S
+    std::vector<bool> membership;      // points[i] in M iff membership[i]
     const unsigned int dim;            // ambient dimension (not to be
     // confused with the rank r,
     // see below)


### PR DESCRIPTION
This PR provides code to support standard arrays as well as std::vector.  This was necessary to be able to integrate Miniball into a project that requires bounding sphere computation from points stored in either arrays or vectors.

In internal storage and usage in the Seb and Subspan classes, `const PointAccessor &S` has been replaced with `const Pt* point` and `const size_t num_points`.  Also, the Seb class has two constructors, the original constructor that accepts a vector -- which initializes points and num_points using the std::vector data() and size() member functions, respectively -- and a new constructor to accept a Pt array and its size directly.

I have made changes to the comments in an attempt to both make the new code clear but also to try to maintain consistent references to your paper, namely by making sure that it's clear that points and num_points refer to the point set S, for example with these comments for Seb's (and Subspan's) private members:

```
    const Pt* points;                 // points and num_points are the set of inserted
    const size_t num_points;          // points, formally referred to as S
```

Since PointAccessor is no longer viable, it has been removed from all template arguments.  Since points were accessed using operator[] in std::vector rather than with an iterator, I don't believe that this reduces STL support since, from my review of applicable STL containers (such as std::list or std::multiset) at [cppreference.com](http://cppreference.com), only std::vector supports access with operator[].
