### PR TITLE
Updated example.c to work with newer versions of g++

### DIFF
--- a/cpp/test/example.C
+++ b/cpp/test/example.C
@@ -7,7 +7,8 @@
 #include <cstdio>
 
 #include "Seb.h"
-#include "Seb_debug.h" // ... only needed because we use Seb::Timer below
+#include "Seb_debug.h"
+#include "Seb_debug.C" // ... only needed because we use Seb::Timer below
 
 int main(int argn,char **argv) {
   typedef double FT;


### PR DESCRIPTION
As in #37, example.c cannot be compiled as written on g++ versions 10 or newer. The following error results from attempting to compile the script:

```bash

g++ -I../main example.C -o example -O3
>Undefined symbols for architecture arm64:
>  "Seb::Timer::lapse(char const*)", referenced from:
>      _main in example-897173.o
>  "Seb::Timer::start(char const*)", referenced from:
>      _main in example-897173.o
>  "Seb::Timer::instance()", referenced from:
>      _main in example-897173.o
>ld: symbol(s) not found for architecture arm64
```

A very similar error is raised on x86-64 linux systems as well. The change proposed in [7532079](https://github.com/hbf/miniball/commit/753207956d6420cbc7e0f7613206ec56a76013ba) works for g++-11, g++-12, g++-13, and g++-14 on macOS arm64 and g++-10 on Red Hat linux x86-64.

The line `#include "Seb_debug.h"` is not required for proper function on any of the versions of g++ tested, but has been left in to improve backwards compatibility.

