### PR TITLE
fix: defer np.typing.ArrayLike annotation evaluation

### DIFF
--- a/python/miniball/__init__.py
+++ b/python/miniball/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from ._miniball import _compute_miniball
 
 import numpy as np


### PR DESCRIPTION
Fix #46 

## Problem

`import miniball` crashes on numpy < 2.0 with:

```
AttributeError: module 'numpy' has no attribute 'typing'
```

The `np.typing.ArrayLike` annotation on `miniball()` is evaluated at import time (no `from __future__ import annotations`), but on numpy 1.x `np.typing` is only accessible after an explicit `import numpy.typing`.

Since `pyproject.toml` declares `numpy` with no version constraint and pip does not upgrade pre-installed packages, any user who already has numpy < 2 installed hits this crash on the very first `import miniball`. nanobind (the only other dependency) does not rescue it.

## Fix

Add `from __future__ import annotations` at the top of `python/miniball/__init__.py`, which defers annotation evaluation (PEP 563).

## Verification

- Reproduced the crash by building from source against numpy 1.26.4
- With the fix, `import miniball` works on numpy 1.26.4 and the computation returns the correct result
- Also verified on numpy 2.5.2
- Existing test suite: 5/5 passed (`pytest python/test/`)